### PR TITLE
Allow to use string company identification number + fix and refactor its testcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ $ares = new Ares();
 $ares->setBalancer('http://some.loadbalancer.domain');
 ```
 
+## Develop
+
+### Running tests suite in local docker environment
+```php
+docker run -v `pwd`:/app -i -t php:7.2-fpm /bin/bash -c "/app/vendor/phpunit/phpunit/phpunit --colors --configuration /app/phpunit.xml /app/tests/"
+```
+
+
 ## Coding standard
 
 ### Check

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -114,7 +114,7 @@ class Ares
             return unserialize(file_get_contents($cachedFile));
         }
 
-        $url = $this->wrapUrl(sprintf(self::URL_BAS, $id));
+        $url = $this->composeUrl(sprintf(self::URL_BAS, $id));
 
         try {
             $aresRequest = file_get_contents($url, null, stream_context_create($this->contextOptions));
@@ -183,7 +183,7 @@ class Ares
         $id = Lib::toInteger($id);
         $this->ensureIdIsInteger($id);
 
-        $url = $this->wrapUrl(sprintf(self::URL_RES, $id));
+        $url = $this->composeUrl(sprintf(self::URL_RES, $id));
 
         $cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
         $cachedFile = $this->cacheDir.'/res_'.$cachedFileName;
@@ -244,7 +244,7 @@ class Ares
         $id = Lib::toInteger($id);
         $this->ensureIdIsInteger($id);
 
-        $url = $this->wrapUrl(sprintf(self::URL_TAX, $id));
+        $url = $this->composeUrl(sprintf(self::URL_TAX, $id));
 
         $cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
         $cachedFile = $this->cacheDir.'/tax_'.$cachedFileName;
@@ -300,7 +300,7 @@ class Ares
             throw new InvalidArgumentException('Zadejte minimálně 3 znaky pro hledání.');
         }
 
-        $url = $this->wrapUrl(sprintf(
+        $url = $this->composeUrl(sprintf(
             self::URL_FIND,
             urlencode(Lib::stripDiacritics($name)),
             urlencode(Lib::stripDiacritics($city))
@@ -397,7 +397,7 @@ class Ares
      *
      * @return string
      */
-    private function wrapUrl($url)
+    private function composeUrl($url)
     {
         if ($this->balancer) {
             $url = sprintf('%s?url=%s', $this->balancer, urlencode($url));

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -99,8 +99,7 @@ class Ares
      */
     public function findByIdentificationNumber($id)
     {
-        $id = Lib::toInteger($id);
-        $this->ensureIdIsInteger($id);
+        $this->checkCompanyId($id);
 
         if (empty($id)) {
             throw new AresException('IČ firmy musí být zadáno.');
@@ -128,8 +127,8 @@ class Ares
                 $data = $aresResponse->children($ns['are']);
                 $elements = $data->children($ns['D'])->VBAS;
 
-                $ico = (int) $elements->ICO;
-                if ($ico !== $id) {
+                $ico = $elements->ICO;
+                if ((string) $ico !== (string) $id) {
                     throw new AresException('IČ firmy nebylo nalezeno.');
                 }
 
@@ -180,8 +179,7 @@ class Ares
      */
     public function findInResById($id)
     {
-        $id = Lib::toInteger($id);
-        $this->ensureIdIsInteger($id);
+        $this->checkCompanyId($id);
 
         $url = $this->composeUrl(sprintf(self::URL_RES, $id));
 
@@ -241,8 +239,7 @@ class Ares
      */
     public function findVatById($id)
     {
-        $id = Lib::toInteger($id);
-        $this->ensureIdIsInteger($id);
+        $this->checkCompanyId($id);
 
         $url = $this->composeUrl(sprintf(self::URL_TAX, $id));
 
@@ -385,9 +382,9 @@ class Ares
     /**
      * @param int $id
      */
-    private function ensureIdIsInteger($id)
+    private function checkCompanyId($id)
     {
-        if (!is_int($id)) {
+        if (!is_numeric($id) || !preg_match('/^\d+$/', $id)) {
             throw new InvalidArgumentException('IČ firmy musí být číslo.');
         }
     }

--- a/tests/AresTest.php
+++ b/tests/AresTest.php
@@ -17,39 +17,109 @@ final class AresTest extends PHPUnit_Framework_TestCase
         $this->ares = new Ares();
     }
 
-    public function testFindByIdentificationNumber()
+    /**
+     * @param $companyId
+     * @param $expectedException
+     * @param $expectedExceptionMessage
+     * @param $expected
+     *
+     * @dataProvider providerTestFindByIdentificationNumber
+     *
+     * @throws Ares\AresException
+     */
+    public function testFindByIdentificationNumber($companyId, $expectedException, $expectedExceptionMessage, $expected)
     {
-        $record = $this->ares->findByIdentificationNumber(73263753);
-        $this->assertSame('Dennis Fridrich', $record->getCompanyName());
-        $this->assertSame('CZ8508095453', $record->getTaxId());
-        $this->assertSame('73263753', $record->getCompanyId());
-        $this->assertEmpty($record->getStreet());
-        $this->assertSame('15', $record->getStreetHouseNumber());
-        $this->assertEmpty($record->getStreetOrientationNumber());
-        $this->assertSame('Petrovice - Obděnice', $record->getTown());
-        $this->assertSame('26255', $record->getZip());
-    }
+        // setup
+        if ($expectedException !== null) {
+            $this->expectException($expectedException);
+        }
+        if ($expectedExceptionMessage !== null) {
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
 
-    public function testFindByIdentificationNumberWithLeadingZeros()
-    {
-        $record = $this->ares->findByIdentificationNumber('00006947');
-        $this->assertSame('00006947', $record->getCompanyId());
+        // when
+        $actual = $this->ares->findByIdentificationNumber($companyId);
+
+        // then
+        $this->assertEquals($expected, $actual);
     }
 
     /**
-     * @expectedException \Defr\Ares\AresException
+     * @return array
      */
-    public function testFindByIdentificationNumberException()
+    public function providerTestFindByIdentificationNumber()
     {
-        $this->ares->findByIdentificationNumber('A1234');
-    }
-
-    /**
-     * @expectedException \Defr\Ares\AresException
-     */
-    public function testFindByEmptyStringException()
-    {
-        $this->ares->findByIdentificationNumber('');
+        return [
+            [
+                // integer ID number
+                'companyId'                => 48136450,
+                'expectedException'        => null,
+                'expectedExceptionMessage' => null,
+                'expected'                 => new Ares\AresRecord(
+                    '48136450',
+                    'CZ48136450',
+                    'ČESKÁ NÁRODNÍ BANKA',
+                    'Na příkopě',
+                    '864',
+                    '28',
+                    'Praha 1 - Nové Město',
+                    '11000'
+                ),
+            ],
+            [
+                // string ID number
+                'companyId'                => '48136450',
+                'expectedException'        => null,
+                'expectedExceptionMessage' => null,
+                'expected'                 => new Ares\AresRecord(
+                    '48136450',
+                    'CZ48136450',
+                    'ČESKÁ NÁRODNÍ BANKA',
+                    'Na příkopě',
+                    '864',
+                    '28',
+                    'Praha 1 - Nové Město',
+                    '11000'
+                ),
+            ],
+            [
+                // string ID number with leading zeros
+                'companyId'                => '00006947',
+                'expectedException'        => null,
+                'expectedExceptionMessage' => null,
+                'expected'                 => new Ares\AresRecord(
+                    '00006947',
+                    'CZ00006947',
+                    'Ministerstvo financí',
+                    'Letenská',
+                    '525',
+                    '15',
+                    'Praha 1 - Malá Strana',
+                    '11800'
+                ),
+            ],
+            [
+                // nonsense string ID number with some charaters in it
+                'companyId'                => 'ABC1234',
+                'expectedException'        => \InvalidArgumentException::class,
+                'expectedExceptionMessage' => 'IČ firmy musí být číslo.',
+                'expected'                 => null,
+            ],
+            [
+                // empty string ID number
+                'companyId'                => '',
+                'expectedException'        => \InvalidArgumentException::class,
+                'expectedExceptionMessage' => 'IČ firmy musí být číslo.',
+                'expected'                 => null,
+            ],
+            [
+                // non-existent ID number
+                'companyId'                => '12345678912345',
+                'expectedException'        => \Defr\Ares\AresException::class,
+                'expectedExceptionMessage' => 'IČ firmy nebylo nalezeno.',
+                'expected'                 => null,
+            ],
+        ];
     }
 
     public function testFindByName()


### PR DESCRIPTION
Hello,
I made some refactoring and cleanup in the `Ares` class. Also I fixed failing test (due to non-existent VAT ID in tested subject) and refactored all test cases for `findByIdentificationNumber` to single test cases that is parametrized via dataprovider function.

Also I've allowed `findByIdentificationNumber` to accept identification number either in string format or integer format instead of just integer format (since company identification number can start with leading zeros) 