### PR TITLE
Make Travis.ci run test again - fixes #24 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
   - composer install --no-interaction --prefer-source
 
 script:
-  - phpunit $PHPUNIT_FLAGS
+  - vendor/phpunit/phpunit/phpunit $PHPUNIT_FLAGS
   - if [[ "$CHECK_CS" != "" ]]; then vendor/bin/symplify-cs check src tests; fi
 
 after_script:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,7 +13,7 @@
         </whitelist>
     </filter>
     <testsuites>
-        <testsuite>
+        <testsuite name="Ares Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
Travis tests were not running at all for quite some time. This PR fixes that (#24 ). 

However there are tests that are failing. Tests for `findByIdentificationNumber` are fixed in my other PR #26 However, there is `testBalancer` that could not ever work. I suggest to remove it from testsuite right now completely since fixing it would require refactoring of code that requests ARES API so that we can mock the HTTP client which is impossible with current solution using `file_get_contents`. What do you think?