### PR TITLE
Implement new API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /bin
 /vendor
 composer.lock

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -2,10 +2,10 @@
 
 namespace Defr;
 
+use Defr\Ares\ApiClient\ApiClient;
 use Defr\Ares\AresException;
 use Defr\Ares\AresRecord;
 use Defr\Ares\AresRecords;
-use Defr\Ares\TaxRecord;
 use InvalidArgumentException;
 
 /**
@@ -16,55 +16,16 @@ use InvalidArgumentException;
  */
 class Ares
 {
+	/** @deprecated no need to be public, will be removed in next major version */
     const URL_BAS = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/darv_bas.cgi?ico=%s';
+	/** @deprecated no need to be public, will be removed in next major version */
     const URL_RES = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/darv_res.cgi?ICO=%s';
+	/** @deprecated no need to be public, will be removed in next major version */
     const URL_TAX = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/ares_es.cgi?ico=%s&filtr=0';
+	/** @deprecated no need to be public, will be removed in next major version */
     const URL_FIND = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/ares_es.cgi?obch_jm=%s&obec=%s&filtr=0';
 
-    /**
-     * @var string
-     */
-    private $cacheStrategy = 'YW';
-
-    /**
-     * Path to directory that serves as an local cache for Ares service responses.
-     *
-     * @var string
-     */
-    private $cacheDir = null;
-
-    /**
-     * Whether we are running in debug/development environment.
-     *
-     * @var bool
-     */
-    private $debug;
-
-    /**
-     * Load balancing domain URL.
-     *
-     * @var string
-     */
-    private $balancer = null;
-
-    /**
-     * Stream context options.
-     *
-     * @var array
-     */
-    private $contextOptions = [
-        'ssl' => [
-            'verify_peer' => false,
-            'verify_peer_name' => false,
-        ],
-    ];
-
-    /**
-     * Last called URL.
-     *
-     * @var string
-     */
-    private $lastUrl;
+	private ApiClient $apiClient;
 
     /**
      * @param string|null $cacheDir
@@ -73,24 +34,11 @@ class Ares
      */
     public function __construct($cacheDir = null, $debug = false, $balancer = null)
     {
-        if (null === $cacheDir) {
-            $cacheDir = sys_get_temp_dir();
-        }
-
-        if (null !== $balancer) {
-            $this->balancer = $balancer;
-        }
-
-        $this->cacheDir = $cacheDir.'/defr/ares';
-        $this->debug = $debug;
-
-        if (!is_dir($this->cacheDir)) {
-            mkdir($this->cacheDir, 0777, true);
-        }
+		$this->apiClient = new ApiClient($cacheDir, $debug, $balancer);
     }
 
     /**
-     * @param $id
+     * @param mixed $id
      *
      * @throws InvalidArgumentException
      * @throws Ares\AresException
@@ -105,79 +53,7 @@ class Ares
             throw new AresException('IČ firmy musí být zadáno.');
         }
 
-        $cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
-        $cachedFile = $this->cacheDir.'/bas_'.$cachedFileName;
-        $cachedRawFile = $this->cacheDir.'/bas_raw_'.$cachedFileName;
-
-        if (is_file($cachedFile)) {
-            return unserialize(file_get_contents($cachedFile));
-        }
-
-        $url = $this->composeUrl(sprintf(self::URL_BAS, $id));
-
-        try {
-            $aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
-            if ($this->debug) {
-                file_put_contents($cachedRawFile, $aresRequest);
-            }
-            $aresResponse = simplexml_load_string($aresRequest);
-
-            if ($aresResponse) {
-                $ns = $aresResponse->getDocNamespaces();
-                $data = $aresResponse->children($ns['are']);
-                $elements = $data->children($ns['D'])->VBAS;
-
-                $ico = $elements->ICO;
-                if ((string) $ico !== (string) $id) {
-                    throw new AresException('IČ firmy nebylo nalezeno.');
-                }
-
-                $record = new AresRecord();
-
-                $record->setCompanyId(strval($elements->ICO));
-                $record->setTaxId(strval($elements->DIC));
-                $record->setCompanyName(strval($elements->OF));
-                if (strval($elements->AA->NU) !== '') {
-                    $record->setStreet(strval($elements->AA->NU));
-                } else {
-                    if (strval($elements->AA->NCO) !== '') {
-                        $record->setStreet(strval($elements->AA->NCO));
-                    }
-                }
-
-                if (strval($elements->AA->CO)) {
-                    $record->setStreetHouseNumber(strval($elements->AA->CD));
-                    $record->setStreetOrientationNumber(strval($elements->AA->CO));
-                } else {
-                    $record->setStreetHouseNumber(strval($elements->AA->CD));
-                }
-
-                if (strval($elements->AA->N) === 'Praha') {
-                    $record->setTown(strval($elements->AA->NMC));
-                    $record->setArea(strval($elements->AA->NCO));
-                } elseif (strval($elements->AA->NCO) !== strval($elements->AA->N)) {
-                    $record->setTown(strval($elements->AA->N));
-                    $record->setArea(strval($elements->AA->NCO));
-                } else {
-                    $record->setTown(strval($elements->AA->N));
-                }
-
-                $record->setZip(strval($elements->AA->PSC));
-
-                $record->setRegisters(strval($elements->PSU));
-
-                $stateInfo = $elements->AA->AU->children($ns['U']);
-                $record->setStateCode(strval($stateInfo->KK));
-            } else {
-                throw new AresException('Databáze ARES není dostupná.');
-            }
-        } catch (\Exception $e) {
-            throw new AresException($e->getMessage());
-        }
-
-        file_put_contents($cachedFile, serialize($record));
-
-        return $record;
+        return $this->apiClient->findByIdentificationNumber($id);
     }
 
     /**
@@ -194,50 +70,7 @@ class Ares
     {
         $this->checkCompanyId($id);
 
-        $url = $this->composeUrl(sprintf(self::URL_RES, $id));
-
-        $cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
-        $cachedFile = $this->cacheDir.'/res_'.$cachedFileName;
-        $cachedRawFile = $this->cacheDir.'/res_raw_'.$cachedFileName;
-
-        if (is_file($cachedFile)) {
-            return unserialize(file_get_contents($cachedFile));
-        }
-
-        try {
-            $aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
-            if ($this->debug) {
-                file_put_contents($cachedRawFile, $aresRequest);
-            }
-            $aresResponse = simplexml_load_string($aresRequest);
-
-            if ($aresResponse) {
-                $ns = $aresResponse->getDocNamespaces();
-                $data = $aresResponse->children($ns['are']);
-                $elements = $data->children($ns['D'])->Vypis_RES;
-
-                if (strval($elements->ZAU->ICO) === $id) {
-                    $record = new AresRecord();
-                    $record->setCompanyId(strval($id));
-                    $record->setTaxId($this->findVatById($id));
-                    $record->setCompanyName(strval($elements->ZAU->OF));
-                    $record->setStreet(strval($elements->SI->NU));
-                    $record->setStreetHouseNumber(strval($elements->SI->CD));
-                    $record->setStreetOrientationNumber(strval($elements->SI->CO));
-                    $record->setTown(strval($elements->SI->N));
-                    $record->setZip(strval($elements->SI->PSC));
-                } else {
-                    throw new AresException('IČ firmy nebylo nalezeno.');
-                }
-            } else {
-                throw new AresException('Databáze ARES není dostupná.');
-            }
-        } catch (\Exception $e) {
-            throw new AresException($e->getMessage());
-        }
-        file_put_contents($cachedFile, serialize($record));
-
-        return $record;
+        return $this->apiClient->findInResById($id);
     }
 
     /**
@@ -248,49 +81,13 @@ class Ares
      * @throws InvalidArgumentException
      * @throws \Exception
      *
-     * @return string
+     * @return AresRecord
      */
     public function findVatById($id)
     {
         $this->checkCompanyId($id);
 
-        $url = $this->composeUrl(sprintf(self::URL_TAX, $id));
-
-        $cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
-        $cachedFile = $this->cacheDir.'/tax_'.$cachedFileName;
-        $cachedRawFile = $this->cacheDir.'/tax_raw_'.$cachedFileName;
-
-        if (is_file($cachedFile)) {
-            return unserialize(file_get_contents($cachedFile));
-        }
-
-        try {
-            $vatRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
-            if ($this->debug) {
-                file_put_contents($cachedRawFile, $vatRequest);
-            }
-            $vatResponse = simplexml_load_string($vatRequest);
-
-            if ($vatResponse) {
-                $record = new TaxRecord();
-                $ns = $vatResponse->getDocNamespaces();
-                $data = $vatResponse->children($ns['are']);
-                $elements = $data->children($ns['dtt'])->V->S;
-
-                if (strval($elements->ico) === $id) {
-                    $record->setTaxId(str_replace('dic=', 'CZ', strval($elements->p_dph)));
-                } else {
-                    throw new AresException('DIČ firmy nebylo nalezeno.');
-                }
-            } else {
-                throw new AresException('Databáze MFČR není dostupná.');
-            }
-        } catch (\Exception $e) {
-            throw new \Exception($e->getMessage());
-        }
-        file_put_contents($cachedFile, serialize($record));
-
-        return $record;
+        return $this->apiClient->findVatById($id);
     }
 
     /**
@@ -310,50 +107,7 @@ class Ares
             throw new InvalidArgumentException('Zadejte minimálně 3 znaky pro hledání.');
         }
 
-        $url = $this->composeUrl(sprintf(
-            self::URL_FIND,
-            urlencode(Lib::stripDiacritics($name)),
-            urlencode(Lib::stripDiacritics($city))
-        ));
-
-        $cachedFileName = date($this->cacheStrategy).'_'.md5($name.$city).'.php';
-        $cachedFile = $this->cacheDir.'/find_'.$cachedFileName;
-        $cachedRawFile = $this->cacheDir.'/find_raw_'.$cachedFileName;
-
-        if (is_file($cachedFile)) {
-            return unserialize(file_get_contents($cachedFile));
-        }
-
-        $aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
-        if ($this->debug) {
-            file_put_contents($cachedRawFile, $aresRequest);
-        }
-        $aresResponse = simplexml_load_string($aresRequest);
-        if (!$aresResponse) {
-            throw new AresException('Databáze ARES není dostupná.');
-        }
-
-        $ns = $aresResponse->getDocNamespaces();
-        $data = $aresResponse->children($ns['are']);
-        $elements = $data->children($ns['dtt'])->V->S;
-
-        if (empty($elements)) {
-            throw new AresException('Nic nebylo nalezeno.');
-        }
-
-        $records = new AresRecords();
-        foreach ($elements as $element) {
-            $record = new AresRecord();
-            $record->setCompanyId(strval($element->ico));
-            $record->setTaxId(
-                ($element->dph ? str_replace('dic=', 'CZ', strval($element->p_dph)) : '')
-            );
-            $record->setCompanyName(strval($element->ojm));
-            $records[] = $record;
-        }
-        file_put_contents($cachedFile, serialize($records));
-
-        return $records;
+		return $this->apiClient->findByName($name, $city);
     }
 
     /**
@@ -361,7 +115,7 @@ class Ares
      */
     public function setCacheStrategy($cacheStrategy)
     {
-        $this->cacheStrategy = $cacheStrategy;
+		$this->apiClient->setCacheStrategy($cacheStrategy);
     }
 
     /**
@@ -369,7 +123,7 @@ class Ares
      */
     public function setDebug($debug)
     {
-        $this->debug = $debug;
+		$this->apiClient->setDebug($debug);
     }
 
     /**
@@ -379,7 +133,7 @@ class Ares
      */
     public function setBalancer($balancer)
     {
-        $this->balancer = $balancer;
+		$this->apiClient->setBalancer($balancer);
 
         return $this;
     }
@@ -389,33 +143,17 @@ class Ares
      */
     public function getLastUrl()
     {
-        return $this->lastUrl;
+        return $this->apiClient->getLastUrl();
     }
 
     /**
-     * @param int $id
+     * @param mixed $id
      */
     private function checkCompanyId($id)
     {
         if (!is_numeric($id) || !preg_match('/^\d+$/', $id)) {
             throw new InvalidArgumentException('IČ firmy musí být číslo.');
         }
-    }
-
-    /**
-     * @param string $url
-     *
-     * @return string
-     */
-    private function composeUrl($url)
-    {
-        if ($this->balancer) {
-            $url = sprintf('%s?url=%s', $this->balancer, urlencode($url));
-        }
-
-        $this->lastUrl = $url;
-
-        return $url;
     }
 
 }

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -4,6 +4,7 @@ namespace Defr;
 
 use Defr\Ares\ApiClient\ApiClient;
 use Defr\Ares\ApiClient\AresV1;
+use Defr\Ares\ApiClient\ResponseCache;
 use Defr\Ares\AresException;
 use Defr\Ares\AresRecord;
 use Defr\Ares\AresRecords;
@@ -33,9 +34,11 @@ class Ares
      * @param bool        $debug
      * @param string|null $balancer
      */
-    public function __construct($cacheDir = null, $debug = false, $balancer = null)
+    public function __construct($cacheDir = null, $debug = false, $balancer = null, ?ApiClient $apiClient = null)
     {
-		$this->apiClient = new AresV1($cacheDir, $debug, $balancer);
+		$this->apiClient = $apiClient !== null
+			? $apiClient
+			: new ResponseCache(new AresV1($balancer), $cacheDir, $debug, $balancer);
     }
 
     /**
@@ -139,6 +142,11 @@ class Ares
         return $this;
     }
 
+	public function setApiClient(ApiClient $apiClient): void
+	{
+		$this->apiClient = $apiClient;
+	}
+
     /**
      * @return string
      */
@@ -146,6 +154,11 @@ class Ares
     {
         return $this->apiClient->getLastUrl();
     }
+
+	public function getLastRawResponse(): ?string
+	{
+		return $this->apiClient->getLastRawResponse();
+	}
 
     /**
      * @param mixed $id

--- a/src/Ares.php
+++ b/src/Ares.php
@@ -3,6 +3,7 @@
 namespace Defr;
 
 use Defr\Ares\ApiClient\ApiClient;
+use Defr\Ares\ApiClient\AresV1;
 use Defr\Ares\AresException;
 use Defr\Ares\AresRecord;
 use Defr\Ares\AresRecords;
@@ -34,7 +35,7 @@ class Ares
      */
     public function __construct($cacheDir = null, $debug = false, $balancer = null)
     {
-		$this->apiClient = new ApiClient($cacheDir, $debug, $balancer);
+		$this->apiClient = new AresV1($cacheDir, $debug, $balancer);
     }
 
     /**

--- a/src/Ares/ApiClient/ApiClient.php
+++ b/src/Ares/ApiClient/ApiClient.php
@@ -1,0 +1,342 @@
+<?php declare(strict_types = 1);
+
+namespace Defr\Ares\ApiClient;
+
+use Defr\Ares\AresException;
+use Defr\Ares\AresRecord;
+use Defr\Ares\AresRecords;
+use Defr\Ares\TaxRecord;
+
+
+class ApiClient
+{
+
+	private const URL_BAS = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/darv_bas.cgi?ico=%s';
+	private const URL_RES = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/darv_res.cgi?ICO=%s';
+	private const URL_TAX = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/ares_es.cgi?ico=%s&filtr=0';
+	private const URL_FIND = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/ares_es.cgi?obch_jm=%s&obec=%s&filtr=0';
+
+	private string $cacheStrategy = 'YW';
+
+	/**
+	 * Path to directory that serves as an local cache for Ares service responses.
+	 */
+	private ?string $cacheDir = null;
+
+	/**
+	 * Whether we are running in debug/development environment.
+	 */
+	private bool $debug;
+
+	/**
+	 * Load balancing domain URL.
+	 */
+	private ?string $balancer = null;
+
+	/**
+	 * Stream context options.
+	 *
+	 * @var array{ssl: array{verify_peer: bool, verify_peer_name: bool}}
+	 */
+	private array $contextOptions = [
+		'ssl' => [
+			'verify_peer' => false,
+			'verify_peer_name' => false,
+		],
+	];
+
+	/**
+	 * Last called URL.
+	 */
+	private string $lastUrl;
+
+	public function __construct(?string $cacheDir = null, bool $debug = false, ?string $balancer = null)
+	{
+		if (null === $cacheDir) {
+			$cacheDir = sys_get_temp_dir();
+		}
+
+		if (null !== $balancer) {
+			$this->balancer = $balancer;
+		}
+
+		$this->cacheDir = $cacheDir.'/defr/ares';
+		$this->debug = $debug;
+
+		if (!is_dir($this->cacheDir)) {
+			mkdir($this->cacheDir, 0777, true);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findByIdentificationNumber($id): AresRecord
+	{
+		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
+		$cachedFile = $this->cacheDir.'/bas_'.$cachedFileName;
+		$cachedRawFile = $this->cacheDir.'/bas_raw_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		$url = $this->composeUrl(sprintf(self::URL_BAS, $id));
+
+		try {
+			$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+			if ($this->debug) {
+				file_put_contents($cachedRawFile, $aresRequest);
+			}
+			$aresResponse = simplexml_load_string($aresRequest);
+
+			if ($aresResponse) {
+				$ns = $aresResponse->getDocNamespaces();
+				$data = $aresResponse->children($ns['are']);
+				$elements = $data->children($ns['D'])->VBAS;
+
+				$ico = $elements->ICO;
+				if ((string) $ico !== (string) $id) {
+					throw new AresException('IČ firmy nebylo nalezeno.');
+				}
+
+				$record = new AresRecord();
+
+				$record->setCompanyId(strval($elements->ICO));
+				$record->setTaxId(strval($elements->DIC));
+				$record->setCompanyName(strval($elements->OF));
+				if (strval($elements->AA->NU) !== '') {
+					$record->setStreet(strval($elements->AA->NU));
+				} else {
+					if (strval($elements->AA->NCO) !== '') {
+						$record->setStreet(strval($elements->AA->NCO));
+					}
+				}
+
+				if (strval($elements->AA->CO)) {
+					$record->setStreetHouseNumber(strval($elements->AA->CD));
+					$record->setStreetOrientationNumber(strval($elements->AA->CO));
+				} else {
+					$record->setStreetHouseNumber(strval($elements->AA->CD));
+				}
+
+				if (strval($elements->AA->N) === 'Praha') {
+					$record->setTown(strval($elements->AA->NMC));
+					$record->setArea(strval($elements->AA->NCO));
+				} elseif (strval($elements->AA->NCO) !== strval($elements->AA->N)) {
+					$record->setTown(strval($elements->AA->N));
+					$record->setArea(strval($elements->AA->NCO));
+				} else {
+					$record->setTown(strval($elements->AA->N));
+				}
+
+				$record->setZip(strval($elements->AA->PSC));
+
+				$record->setRegisters(strval($elements->PSU));
+
+				$stateInfo = $elements->AA->AU->children($ns['U']);
+				$record->setStateCode(strval($stateInfo->KK));
+			} else {
+				throw new AresException('Databáze ARES není dostupná.');
+			}
+		} catch (\Exception $e) {
+			throw new AresException($e->getMessage());
+		}
+
+		file_put_contents($cachedFile, serialize($record));
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findInResById(int $id): AresRecord
+	{
+		$url = $this->composeUrl(sprintf(self::URL_RES, $id));
+
+		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
+		$cachedFile = $this->cacheDir.'/res_'.$cachedFileName;
+		$cachedRawFile = $this->cacheDir.'/res_raw_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		try {
+			$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+			if ($this->debug) {
+				file_put_contents($cachedRawFile, $aresRequest);
+			}
+			$aresResponse = simplexml_load_string($aresRequest);
+
+			if ($aresResponse) {
+				$ns = $aresResponse->getDocNamespaces();
+				$data = $aresResponse->children($ns['are']);
+				$elements = $data->children($ns['D'])->Vypis_RES;
+
+				if (strval($elements->ZAU->ICO) === $id) {
+					$record = new AresRecord();
+					$record->setCompanyId(strval($id));
+					$record->setTaxId($this->findVatById($id));
+					$record->setCompanyName(strval($elements->ZAU->OF));
+					$record->setStreet(strval($elements->SI->NU));
+					$record->setStreetHouseNumber(strval($elements->SI->CD));
+					$record->setStreetOrientationNumber(strval($elements->SI->CO));
+					$record->setTown(strval($elements->SI->N));
+					$record->setZip(strval($elements->SI->PSC));
+				} else {
+					throw new AresException('IČ firmy nebylo nalezeno.');
+				}
+			} else {
+				throw new AresException('Databáze ARES není dostupná.');
+			}
+		} catch (\Exception $e) {
+			throw new AresException($e->getMessage());
+		}
+		file_put_contents($cachedFile, serialize($record));
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findVatById(int $id): AresRecord
+	{
+		$url = $this->composeUrl(sprintf(self::URL_TAX, $id));
+
+		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
+		$cachedFile = $this->cacheDir.'/tax_'.$cachedFileName;
+		$cachedRawFile = $this->cacheDir.'/tax_raw_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		try {
+			$vatRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+			if ($this->debug) {
+				file_put_contents($cachedRawFile, $vatRequest);
+			}
+			$vatResponse = simplexml_load_string($vatRequest);
+
+			if ($vatResponse) {
+				$record = new TaxRecord();
+				$ns = $vatResponse->getDocNamespaces();
+				$data = $vatResponse->children($ns['are']);
+				$elements = $data->children($ns['dtt'])->V->S;
+
+				if (strval($elements->ico) === $id) {
+					$record->setTaxId(str_replace('dic=', 'CZ', strval($elements->p_dph)));
+				} else {
+					throw new AresException('DIČ firmy nebylo nalezeno.');
+				}
+			} else {
+				throw new AresException('Databáze MFČR není dostupná.');
+			}
+		} catch (\Exception $e) {
+			throw new \Exception($e->getMessage());
+		}
+		file_put_contents($cachedFile, serialize($record));
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findByName(string $name, ?string $city = null)
+	{
+		$url = $this->composeUrl(sprintf(
+			self::URL_FIND,
+			urlencode(Lib::stripDiacritics($name)),
+			urlencode(Lib::stripDiacritics($city))
+		));
+
+		$cachedFileName = date($this->cacheStrategy).'_'.md5($name.$city).'.php';
+		$cachedFile = $this->cacheDir.'/find_'.$cachedFileName;
+		$cachedRawFile = $this->cacheDir.'/find_raw_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+		if ($this->debug) {
+			file_put_contents($cachedRawFile, $aresRequest);
+		}
+		$aresResponse = simplexml_load_string($aresRequest);
+		if (!$aresResponse) {
+			throw new AresException('Databáze ARES není dostupná.');
+		}
+
+		$ns = $aresResponse->getDocNamespaces();
+		$data = $aresResponse->children($ns['are']);
+		$elements = $data->children($ns['dtt'])->V->S;
+
+		if (empty($elements)) {
+			throw new AresException('Nic nebylo nalezeno.');
+		}
+
+		$records = new AresRecords();
+		foreach ($elements as $element) {
+			$record = new AresRecord();
+			$record->setCompanyId(strval($element->ico));
+			$record->setTaxId(
+				($element->dph ? str_replace('dic=', 'CZ', strval($element->p_dph)) : '')
+			);
+			$record->setCompanyName(strval($element->ojm));
+			$records[] = $record;
+		}
+		file_put_contents($cachedFile, serialize($records));
+
+		return $records;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setCacheStrategy(string $cacheStrategy): void
+	{
+		$this->cacheStrategy = $cacheStrategy;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setDebug(bool $debug): void
+	{
+		$this->debug = $debug;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setBalancer(string $balancer)
+	{
+		$this->balancer = $balancer;
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getLastUrl(): string
+	{
+		return $this->lastUrl;
+	}
+
+	private function composeUrl(string $url): string
+	{
+		if ($this->balancer) {
+			$url = sprintf('%s?url=%s', $this->balancer, urlencode($url));
+		}
+
+		$this->lastUrl = $url;
+
+		return $url;
+	}
+
+}

--- a/src/Ares/ApiClient/ApiClient.php
+++ b/src/Ares/ApiClient/ApiClient.php
@@ -5,338 +5,49 @@ namespace Defr\Ares\ApiClient;
 use Defr\Ares\AresException;
 use Defr\Ares\AresRecord;
 use Defr\Ares\AresRecords;
-use Defr\Ares\TaxRecord;
 
 
-class ApiClient
+interface ApiClient
 {
 
-	private const URL_BAS = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/darv_bas.cgi?ico=%s';
-	private const URL_RES = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/darv_res.cgi?ICO=%s';
-	private const URL_TAX = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/ares_es.cgi?ico=%s&filtr=0';
-	private const URL_FIND = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/ares_es.cgi?obch_jm=%s&obec=%s&filtr=0';
-
-	private string $cacheStrategy = 'YW';
-
 	/**
-	 * Path to directory that serves as an local cache for Ares service responses.
+	 * @param mixed $id
+	 * @throws AresException
 	 */
-	private ?string $cacheDir = null;
+	public function findByIdentificationNumber($id): AresRecord;
 
 	/**
-	 * Whether we are running in debug/development environment.
-	 */
-	private bool $debug;
-
-	/**
-	 * Load balancing domain URL.
-	 */
-	private ?string $balancer = null;
-
-	/**
-	 * Stream context options.
+	 * Find subject in RES (Registr ekonomických subjektů)
 	 *
-	 * @var array{ssl: array{verify_peer: bool, verify_peer_name: bool}}
+	 * @throws AresException
 	 */
-	private array $contextOptions = [
-		'ssl' => [
-			'verify_peer' => false,
-			'verify_peer_name' => false,
-		],
-	];
+	public function findInResById(int $id): AresRecord;
 
 	/**
-	 * Last called URL.
+	 * Find subject's tax ID in OR (Obchodní rejstřík).
+	 *
+	 * @throws \Exception
 	 */
-	private string $lastUrl;
-
-	public function __construct(?string $cacheDir = null, bool $debug = false, ?string $balancer = null)
-	{
-		if (null === $cacheDir) {
-			$cacheDir = sys_get_temp_dir();
-		}
-
-		if (null !== $balancer) {
-			$this->balancer = $balancer;
-		}
-
-		$this->cacheDir = $cacheDir.'/defr/ares';
-		$this->debug = $debug;
-
-		if (!is_dir($this->cacheDir)) {
-			mkdir($this->cacheDir, 0777, true);
-		}
-	}
+	public function findVatById(int $id): AresRecord;
 
 	/**
-	 * {@inheritDoc}
+	 * Find subject by its name in OR (Obchodní rejstřík).
+	 *
+	 * @throws AresException
+	 *
+	 * @return array|AresRecord[]|AresRecords
 	 */
-	public function findByIdentificationNumber($id): AresRecord
-	{
-		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
-		$cachedFile = $this->cacheDir.'/bas_'.$cachedFileName;
-		$cachedRawFile = $this->cacheDir.'/bas_raw_'.$cachedFileName;
+	public function findByName(string $name, ?string $city = null);
 
-		if (is_file($cachedFile)) {
-			return unserialize(file_get_contents($cachedFile));
-		}
+	public function setCacheStrategy(string $cacheStrategy): void;
 
-		$url = $this->composeUrl(sprintf(self::URL_BAS, $id));
-
-		try {
-			$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
-			if ($this->debug) {
-				file_put_contents($cachedRawFile, $aresRequest);
-			}
-			$aresResponse = simplexml_load_string($aresRequest);
-
-			if ($aresResponse) {
-				$ns = $aresResponse->getDocNamespaces();
-				$data = $aresResponse->children($ns['are']);
-				$elements = $data->children($ns['D'])->VBAS;
-
-				$ico = $elements->ICO;
-				if ((string) $ico !== (string) $id) {
-					throw new AresException('IČ firmy nebylo nalezeno.');
-				}
-
-				$record = new AresRecord();
-
-				$record->setCompanyId(strval($elements->ICO));
-				$record->setTaxId(strval($elements->DIC));
-				$record->setCompanyName(strval($elements->OF));
-				if (strval($elements->AA->NU) !== '') {
-					$record->setStreet(strval($elements->AA->NU));
-				} else {
-					if (strval($elements->AA->NCO) !== '') {
-						$record->setStreet(strval($elements->AA->NCO));
-					}
-				}
-
-				if (strval($elements->AA->CO)) {
-					$record->setStreetHouseNumber(strval($elements->AA->CD));
-					$record->setStreetOrientationNumber(strval($elements->AA->CO));
-				} else {
-					$record->setStreetHouseNumber(strval($elements->AA->CD));
-				}
-
-				if (strval($elements->AA->N) === 'Praha') {
-					$record->setTown(strval($elements->AA->NMC));
-					$record->setArea(strval($elements->AA->NCO));
-				} elseif (strval($elements->AA->NCO) !== strval($elements->AA->N)) {
-					$record->setTown(strval($elements->AA->N));
-					$record->setArea(strval($elements->AA->NCO));
-				} else {
-					$record->setTown(strval($elements->AA->N));
-				}
-
-				$record->setZip(strval($elements->AA->PSC));
-
-				$record->setRegisters(strval($elements->PSU));
-
-				$stateInfo = $elements->AA->AU->children($ns['U']);
-				$record->setStateCode(strval($stateInfo->KK));
-			} else {
-				throw new AresException('Databáze ARES není dostupná.');
-			}
-		} catch (\Exception $e) {
-			throw new AresException($e->getMessage());
-		}
-
-		file_put_contents($cachedFile, serialize($record));
-
-		return $record;
-	}
+	public function setDebug(bool $debug): void;
 
 	/**
-	 * {@inheritDoc}
+	 * @return static
 	 */
-	public function findInResById(int $id): AresRecord
-	{
-		$url = $this->composeUrl(sprintf(self::URL_RES, $id));
+	public function setBalancer(string $balancer);
 
-		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
-		$cachedFile = $this->cacheDir.'/res_'.$cachedFileName;
-		$cachedRawFile = $this->cacheDir.'/res_raw_'.$cachedFileName;
-
-		if (is_file($cachedFile)) {
-			return unserialize(file_get_contents($cachedFile));
-		}
-
-		try {
-			$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
-			if ($this->debug) {
-				file_put_contents($cachedRawFile, $aresRequest);
-			}
-			$aresResponse = simplexml_load_string($aresRequest);
-
-			if ($aresResponse) {
-				$ns = $aresResponse->getDocNamespaces();
-				$data = $aresResponse->children($ns['are']);
-				$elements = $data->children($ns['D'])->Vypis_RES;
-
-				if (strval($elements->ZAU->ICO) === $id) {
-					$record = new AresRecord();
-					$record->setCompanyId(strval($id));
-					$record->setTaxId($this->findVatById($id));
-					$record->setCompanyName(strval($elements->ZAU->OF));
-					$record->setStreet(strval($elements->SI->NU));
-					$record->setStreetHouseNumber(strval($elements->SI->CD));
-					$record->setStreetOrientationNumber(strval($elements->SI->CO));
-					$record->setTown(strval($elements->SI->N));
-					$record->setZip(strval($elements->SI->PSC));
-				} else {
-					throw new AresException('IČ firmy nebylo nalezeno.');
-				}
-			} else {
-				throw new AresException('Databáze ARES není dostupná.');
-			}
-		} catch (\Exception $e) {
-			throw new AresException($e->getMessage());
-		}
-		file_put_contents($cachedFile, serialize($record));
-
-		return $record;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function findVatById(int $id): AresRecord
-	{
-		$url = $this->composeUrl(sprintf(self::URL_TAX, $id));
-
-		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
-		$cachedFile = $this->cacheDir.'/tax_'.$cachedFileName;
-		$cachedRawFile = $this->cacheDir.'/tax_raw_'.$cachedFileName;
-
-		if (is_file($cachedFile)) {
-			return unserialize(file_get_contents($cachedFile));
-		}
-
-		try {
-			$vatRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
-			if ($this->debug) {
-				file_put_contents($cachedRawFile, $vatRequest);
-			}
-			$vatResponse = simplexml_load_string($vatRequest);
-
-			if ($vatResponse) {
-				$record = new TaxRecord();
-				$ns = $vatResponse->getDocNamespaces();
-				$data = $vatResponse->children($ns['are']);
-				$elements = $data->children($ns['dtt'])->V->S;
-
-				if (strval($elements->ico) === $id) {
-					$record->setTaxId(str_replace('dic=', 'CZ', strval($elements->p_dph)));
-				} else {
-					throw new AresException('DIČ firmy nebylo nalezeno.');
-				}
-			} else {
-				throw new AresException('Databáze MFČR není dostupná.');
-			}
-		} catch (\Exception $e) {
-			throw new \Exception($e->getMessage());
-		}
-		file_put_contents($cachedFile, serialize($record));
-
-		return $record;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function findByName(string $name, ?string $city = null)
-	{
-		$url = $this->composeUrl(sprintf(
-			self::URL_FIND,
-			urlencode(Lib::stripDiacritics($name)),
-			urlencode(Lib::stripDiacritics($city))
-		));
-
-		$cachedFileName = date($this->cacheStrategy).'_'.md5($name.$city).'.php';
-		$cachedFile = $this->cacheDir.'/find_'.$cachedFileName;
-		$cachedRawFile = $this->cacheDir.'/find_raw_'.$cachedFileName;
-
-		if (is_file($cachedFile)) {
-			return unserialize(file_get_contents($cachedFile));
-		}
-
-		$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
-		if ($this->debug) {
-			file_put_contents($cachedRawFile, $aresRequest);
-		}
-		$aresResponse = simplexml_load_string($aresRequest);
-		if (!$aresResponse) {
-			throw new AresException('Databáze ARES není dostupná.');
-		}
-
-		$ns = $aresResponse->getDocNamespaces();
-		$data = $aresResponse->children($ns['are']);
-		$elements = $data->children($ns['dtt'])->V->S;
-
-		if (empty($elements)) {
-			throw new AresException('Nic nebylo nalezeno.');
-		}
-
-		$records = new AresRecords();
-		foreach ($elements as $element) {
-			$record = new AresRecord();
-			$record->setCompanyId(strval($element->ico));
-			$record->setTaxId(
-				($element->dph ? str_replace('dic=', 'CZ', strval($element->p_dph)) : '')
-			);
-			$record->setCompanyName(strval($element->ojm));
-			$records[] = $record;
-		}
-		file_put_contents($cachedFile, serialize($records));
-
-		return $records;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function setCacheStrategy(string $cacheStrategy): void
-	{
-		$this->cacheStrategy = $cacheStrategy;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function setDebug(bool $debug): void
-	{
-		$this->debug = $debug;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function setBalancer(string $balancer)
-	{
-		$this->balancer = $balancer;
-
-		return $this;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function getLastUrl(): string
-	{
-		return $this->lastUrl;
-	}
-
-	private function composeUrl(string $url): string
-	{
-		if ($this->balancer) {
-			$url = sprintf('%s?url=%s', $this->balancer, urlencode($url));
-		}
-
-		$this->lastUrl = $url;
-
-		return $url;
-	}
+	public function getLastUrl(): string;
 
 }

--- a/src/Ares/ApiClient/ApiClient.php
+++ b/src/Ares/ApiClient/ApiClient.php
@@ -50,4 +50,6 @@ interface ApiClient
 
 	public function getLastUrl(): string;
 
+	public function getLastRawResponse(): ?string;
+
 }

--- a/src/Ares/ApiClient/AresV1.php
+++ b/src/Ares/ApiClient/AresV1.php
@@ -6,6 +6,7 @@ use Defr\Ares\AresException;
 use Defr\Ares\AresRecord;
 use Defr\Ares\AresRecords;
 use Defr\Ares\TaxRecord;
+use Defr\Lib;
 
 
 class AresV1 implements ApiClient

--- a/src/Ares/ApiClient/AresV1.php
+++ b/src/Ares/ApiClient/AresV1.php
@@ -1,0 +1,342 @@
+<?php declare(strict_types = 1);
+
+namespace Defr\Ares\ApiClient;
+
+use Defr\Ares\AresException;
+use Defr\Ares\AresRecord;
+use Defr\Ares\AresRecords;
+use Defr\Ares\TaxRecord;
+
+
+class AresV1 implements ApiClient
+{
+
+	private const URL_BAS = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/darv_bas.cgi?ico=%s';
+	private const URL_RES = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/darv_res.cgi?ICO=%s';
+	private const URL_TAX = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/ares_es.cgi?ico=%s&filtr=0';
+	private const URL_FIND = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/ares_es.cgi?obch_jm=%s&obec=%s&filtr=0';
+
+	private string $cacheStrategy = 'YW';
+
+	/**
+	 * Path to directory that serves as an local cache for Ares service responses.
+	 */
+	private ?string $cacheDir = null;
+
+	/**
+	 * Whether we are running in debug/development environment.
+	 */
+	private bool $debug;
+
+	/**
+	 * Load balancing domain URL.
+	 */
+	private ?string $balancer = null;
+
+	/**
+	 * Stream context options.
+	 *
+	 * @var array{ssl: array{verify_peer: bool, verify_peer_name: bool}}
+	 */
+	private array $contextOptions = [
+		'ssl' => [
+			'verify_peer' => false,
+			'verify_peer_name' => false,
+		],
+	];
+
+	/**
+	 * Last called URL.
+	 */
+	private string $lastUrl;
+
+	public function __construct(?string $cacheDir = null, bool $debug = false, ?string $balancer = null)
+	{
+		if (null === $cacheDir) {
+			$cacheDir = sys_get_temp_dir();
+		}
+
+		if (null !== $balancer) {
+			$this->balancer = $balancer;
+		}
+
+		$this->cacheDir = $cacheDir.'/defr/ares';
+		$this->debug = $debug;
+
+		if (!is_dir($this->cacheDir)) {
+			mkdir($this->cacheDir, 0777, true);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findByIdentificationNumber($id): AresRecord
+	{
+		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
+		$cachedFile = $this->cacheDir.'/bas_'.$cachedFileName;
+		$cachedRawFile = $this->cacheDir.'/bas_raw_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		$url = $this->composeUrl(sprintf(self::URL_BAS, $id));
+
+		try {
+			$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+			if ($this->debug) {
+				file_put_contents($cachedRawFile, $aresRequest);
+			}
+			$aresResponse = simplexml_load_string($aresRequest);
+
+			if ($aresResponse) {
+				$ns = $aresResponse->getDocNamespaces();
+				$data = $aresResponse->children($ns['are']);
+				$elements = $data->children($ns['D'])->VBAS;
+
+				$ico = $elements->ICO;
+				if ((string) $ico !== (string) $id) {
+					throw new AresException('IČ firmy nebylo nalezeno.');
+				}
+
+				$record = new AresRecord();
+
+				$record->setCompanyId(strval($elements->ICO));
+				$record->setTaxId(strval($elements->DIC));
+				$record->setCompanyName(strval($elements->OF));
+				if (strval($elements->AA->NU) !== '') {
+					$record->setStreet(strval($elements->AA->NU));
+				} else {
+					if (strval($elements->AA->NCO) !== '') {
+						$record->setStreet(strval($elements->AA->NCO));
+					}
+				}
+
+				if (strval($elements->AA->CO)) {
+					$record->setStreetHouseNumber(strval($elements->AA->CD));
+					$record->setStreetOrientationNumber(strval($elements->AA->CO));
+				} else {
+					$record->setStreetHouseNumber(strval($elements->AA->CD));
+				}
+
+				if (strval($elements->AA->N) === 'Praha') {
+					$record->setTown(strval($elements->AA->NMC));
+					$record->setArea(strval($elements->AA->NCO));
+				} elseif (strval($elements->AA->NCO) !== strval($elements->AA->N)) {
+					$record->setTown(strval($elements->AA->N));
+					$record->setArea(strval($elements->AA->NCO));
+				} else {
+					$record->setTown(strval($elements->AA->N));
+				}
+
+				$record->setZip(strval($elements->AA->PSC));
+
+				$record->setRegisters(strval($elements->PSU));
+
+				$stateInfo = $elements->AA->AU->children($ns['U']);
+				$record->setStateCode(strval($stateInfo->KK));
+			} else {
+				throw new AresException('Databáze ARES není dostupná.');
+			}
+		} catch (\Exception $e) {
+			throw new AresException($e->getMessage());
+		}
+
+		file_put_contents($cachedFile, serialize($record));
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findInResById(int $id): AresRecord
+	{
+		$url = $this->composeUrl(sprintf(self::URL_RES, $id));
+
+		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
+		$cachedFile = $this->cacheDir.'/res_'.$cachedFileName;
+		$cachedRawFile = $this->cacheDir.'/res_raw_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		try {
+			$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+			if ($this->debug) {
+				file_put_contents($cachedRawFile, $aresRequest);
+			}
+			$aresResponse = simplexml_load_string($aresRequest);
+
+			if ($aresResponse) {
+				$ns = $aresResponse->getDocNamespaces();
+				$data = $aresResponse->children($ns['are']);
+				$elements = $data->children($ns['D'])->Vypis_RES;
+
+				if (strval($elements->ZAU->ICO) === $id) {
+					$record = new AresRecord();
+					$record->setCompanyId(strval($id));
+					$record->setTaxId($this->findVatById($id));
+					$record->setCompanyName(strval($elements->ZAU->OF));
+					$record->setStreet(strval($elements->SI->NU));
+					$record->setStreetHouseNumber(strval($elements->SI->CD));
+					$record->setStreetOrientationNumber(strval($elements->SI->CO));
+					$record->setTown(strval($elements->SI->N));
+					$record->setZip(strval($elements->SI->PSC));
+				} else {
+					throw new AresException('IČ firmy nebylo nalezeno.');
+				}
+			} else {
+				throw new AresException('Databáze ARES není dostupná.');
+			}
+		} catch (\Exception $e) {
+			throw new AresException($e->getMessage());
+		}
+		file_put_contents($cachedFile, serialize($record));
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findVatById(int $id): AresRecord
+	{
+		$url = $this->composeUrl(sprintf(self::URL_TAX, $id));
+
+		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
+		$cachedFile = $this->cacheDir.'/tax_'.$cachedFileName;
+		$cachedRawFile = $this->cacheDir.'/tax_raw_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		try {
+			$vatRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+			if ($this->debug) {
+				file_put_contents($cachedRawFile, $vatRequest);
+			}
+			$vatResponse = simplexml_load_string($vatRequest);
+
+			if ($vatResponse) {
+				$record = new TaxRecord();
+				$ns = $vatResponse->getDocNamespaces();
+				$data = $vatResponse->children($ns['are']);
+				$elements = $data->children($ns['dtt'])->V->S;
+
+				if (strval($elements->ico) === $id) {
+					$record->setTaxId(str_replace('dic=', 'CZ', strval($elements->p_dph)));
+				} else {
+					throw new AresException('DIČ firmy nebylo nalezeno.');
+				}
+			} else {
+				throw new AresException('Databáze MFČR není dostupná.');
+			}
+		} catch (\Exception $e) {
+			throw new \Exception($e->getMessage());
+		}
+		file_put_contents($cachedFile, serialize($record));
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findByName(string $name, ?string $city = null)
+	{
+		$url = $this->composeUrl(sprintf(
+			self::URL_FIND,
+			urlencode(Lib::stripDiacritics($name)),
+			urlencode(Lib::stripDiacritics($city))
+		));
+
+		$cachedFileName = date($this->cacheStrategy).'_'.md5($name.$city).'.php';
+		$cachedFile = $this->cacheDir.'/find_'.$cachedFileName;
+		$cachedRawFile = $this->cacheDir.'/find_raw_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+		if ($this->debug) {
+			file_put_contents($cachedRawFile, $aresRequest);
+		}
+		$aresResponse = simplexml_load_string($aresRequest);
+		if (!$aresResponse) {
+			throw new AresException('Databáze ARES není dostupná.');
+		}
+
+		$ns = $aresResponse->getDocNamespaces();
+		$data = $aresResponse->children($ns['are']);
+		$elements = $data->children($ns['dtt'])->V->S;
+
+		if (empty($elements)) {
+			throw new AresException('Nic nebylo nalezeno.');
+		}
+
+		$records = new AresRecords();
+		foreach ($elements as $element) {
+			$record = new AresRecord();
+			$record->setCompanyId(strval($element->ico));
+			$record->setTaxId(
+				($element->dph ? str_replace('dic=', 'CZ', strval($element->p_dph)) : '')
+			);
+			$record->setCompanyName(strval($element->ojm));
+			$records[] = $record;
+		}
+		file_put_contents($cachedFile, serialize($records));
+
+		return $records;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setCacheStrategy(string $cacheStrategy): void
+	{
+		$this->cacheStrategy = $cacheStrategy;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setDebug(bool $debug): void
+	{
+		$this->debug = $debug;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setBalancer(string $balancer)
+	{
+		$this->balancer = $balancer;
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getLastUrl(): string
+	{
+		return $this->lastUrl;
+	}
+
+	private function composeUrl(string $url): string
+	{
+		if ($this->balancer) {
+			$url = sprintf('%s?url=%s', $this->balancer, urlencode($url));
+		}
+
+		$this->lastUrl = $url;
+
+		return $url;
+	}
+
+}

--- a/src/Ares/ApiClient/AresV2.php
+++ b/src/Ares/ApiClient/AresV2.php
@@ -1,0 +1,279 @@
+<?php declare(strict_types = 1);
+
+namespace Defr\Ares\ApiClient;
+
+use Defr\Ares\AresException;
+use Defr\Ares\AresRecord;
+use Defr\Ares\AresRecords;
+use Defr\Ares\TaxRecord;
+use Defr\Lib;
+
+
+class AresV2 implements ApiClient
+{
+
+	private const URL_BAS = 'https://ares.gov.cz/ekonomicke-subjekty-v-be/rest/ekonomicke-subjekty/%s';
+	private const URL_RES = 'https://ares.gov.cz/ekonomicke-subjekty-v-be/rest/ekonomicke-subjekty/res/%s';
+	// todo url?
+	private const URL_TAX = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/ares_es.cgi?ico=%s&filtr=0';
+	// todo url?
+	private const URL_FIND = 'https://wwwinfo.mfcr.cz/cgi-bin/ares/ares_es.cgi?obch_jm=%s&obec=%s&filtr=0';
+
+	/**
+	 * Load balancing domain URL.
+	 */
+	private ?string $balancer = null;
+
+	/**
+	 * Stream context options.
+	 *
+	 * @var array{ssl: array{verify_peer: bool, verify_peer_name: bool}}
+	 */
+	private array $contextOptions = [
+		'ssl' => [
+			'verify_peer' => false,
+			'verify_peer_name' => false,
+		],
+	];
+
+	/**
+	 * Last called URL.
+	 */
+	private string $lastUrl;
+
+	private ?string $lastRawResponse = null;
+
+	public function __construct(?string $balancer = null)
+	{
+		if (null !== $balancer) {
+			$this->balancer = $balancer;
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findByIdentificationNumber($id): AresRecord
+	{
+		$url = $this->composeUrl(sprintf(self::URL_BAS, $id));
+
+		try {
+			$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+			$this->lastRawResponse = $aresRequest;
+			$aresResponse = json_decode($aresRequest);
+
+			if ($aresResponse) {
+				$ico = $aresResponse->ico;
+				if ((string) $ico !== (string) $id) {
+					throw new AresException('IČ firmy nebylo nalezeno.');
+				}
+
+				$record = new AresRecord();
+
+				$record->setCompanyId(strval($aresResponse->ico));
+				$record->setTaxId('CZ'.$aresResponse->dic);
+				$record->setCompanyName(strval($aresResponse->obchodniJmeno));
+				$record->setStreet(strval($aresResponse->sidlo->nazevUlice));
+				$record->setStreetHouseNumber(strval($aresResponse->sidlo->cisloDomovni));
+				$record->setStreetOrientationNumber($aresResponse->sidlo->cisloOrientacni . ($aresResponse->sidlo->cisloOrientacniPismeno ?? ''));
+
+				if (strval($aresResponse->sidlo->nazevObce) === 'Praha') {
+					$record->setTown(strval($aresResponse->sidlo->nazevMestskeCastiObvodu));
+					$record->setArea(strval($aresResponse->sidlo->nazevCastiObce));
+				} elseif (strval($aresResponse->sidlo->nazevCastiObce) !== strval($aresResponse->sidlo->nazevObce)) {
+					$record->setTown(strval($aresResponse->sidlo->nazevObce));
+					$record->setArea(strval($aresResponse->sidlo->nazevCastiObce));
+				} else {
+					$record->setTown($aresResponse->sidlo->nazevObce);
+				}
+
+				$record->setZip(strval($aresResponse->sidlo->psc));
+
+				// todo A/N are present, but don't know where E/Z could be taken from
+				$record->setRegisters(strval($aresResponse->seznamRegistraci->stavZdrojeVr ?? null));
+
+				// todo this does not match in all cases
+				$record->setStateCode(strval($aresResponse->sidlo->kodKraje ?? null));
+			} else {
+				throw new AresException('Databáze ARES není dostupná.');
+			}
+		} catch (\Exception $e) {
+			throw new AresException($e->getMessage());
+		}
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findInResById(int $id): AresRecord
+	{
+		$url = $this->composeUrl(sprintf(self::URL_RES, $id));
+
+		try {
+			$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+			$this->lastRawResponse = $aresRequest;
+			$aresResponse = json_decode($aresRequest);
+
+			// todo rewrite
+
+			if ($aresResponse) {
+				$ns = $aresResponse->getDocNamespaces();
+				$data = $aresResponse->children($ns['are']);
+				$elements = $data->children($ns['D'])->Vypis_RES;
+
+				if (strval($elements->ZAU->ICO) === $id) {
+					$record = new AresRecord();
+					$record->setCompanyId(strval($id));
+					$record->setTaxId($this->findVatById($id));
+					$record->setCompanyName(strval($elements->ZAU->OF));
+					$record->setStreet(strval($elements->SI->NU));
+					$record->setStreetHouseNumber(strval($elements->SI->CD));
+					$record->setStreetOrientationNumber(strval($elements->SI->CO));
+					$record->setTown(strval($elements->SI->N));
+					$record->setZip(strval($elements->SI->PSC));
+				} else {
+					throw new AresException('IČ firmy nebylo nalezeno.');
+				}
+			} else {
+				throw new AresException('Databáze ARES není dostupná.');
+			}
+		} catch (\Exception $e) {
+			throw new AresException($e->getMessage());
+		}
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findVatById(int $id): AresRecord
+	{
+		$url = $this->composeUrl(sprintf(self::URL_TAX, $id));
+
+		try {
+			$vatRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+			$this->lastRawResponse = $vatRequest;
+			$vatResponse = json_decode($vatRequest);
+
+			// todo rewrite
+
+			if ($vatResponse) {
+				$record = new TaxRecord();
+				$ns = $vatResponse->getDocNamespaces();
+				$data = $vatResponse->children($ns['are']);
+				$elements = $data->children($ns['dtt'])->V->S;
+
+				if (strval($elements->ico) === $id) {
+					$record->setTaxId(str_replace('dic=', 'CZ', strval($elements->p_dph)));
+				} else {
+					throw new AresException('DIČ firmy nebylo nalezeno.');
+				}
+			} else {
+				throw new AresException('Databáze MFČR není dostupná.');
+			}
+		} catch (\Exception $e) {
+			throw new \Exception($e->getMessage());
+		}
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findByName(string $name, ?string $city = null)
+	{
+		$url = $this->composeUrl(sprintf(
+			self::URL_FIND,
+			urlencode(Lib::stripDiacritics($name)),
+			urlencode(Lib::stripDiacritics($city))
+		));
+
+		$aresRequest = file_get_contents($url, false, stream_context_create($this->contextOptions));
+		$this->lastRawResponse = $aresRequest;
+		$aresResponse = json_decode($aresRequest);
+		if (!$aresResponse) {
+			throw new AresException('Databáze ARES není dostupná.');
+		}
+
+		// todo rewrite
+
+		$ns = $aresResponse->getDocNamespaces();
+		$data = $aresResponse->children($ns['are']);
+		$elements = $data->children($ns['dtt'])->V->S;
+
+		if (empty($elements)) {
+			throw new AresException('Nic nebylo nalezeno.');
+		}
+
+		$records = new AresRecords();
+		foreach ($elements as $element) {
+			$record = new AresRecord();
+			$record->setCompanyId(strval($element->ico));
+			$record->setTaxId(
+				($element->dph ? str_replace('dic=', 'CZ', strval($element->p_dph)) : '')
+			);
+			$record->setCompanyName(strval($element->ojm));
+			$records[] = $record;
+		}
+
+		return $records;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setCacheStrategy(string $cacheStrategy): void
+	{
+		$this->cacheStrategy = $cacheStrategy;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setDebug(bool $debug): void
+	{
+		$this->debug = $debug;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setBalancer(string $balancer)
+	{
+		$this->balancer = $balancer;
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getLastUrl(): string
+	{
+		return $this->lastUrl;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getLastRawResponse(): ?string
+	{
+		return $this->lastRawResponse;
+	}
+
+	private function composeUrl(string $url): string
+	{
+		if ($this->balancer) {
+			$url = sprintf('%s?url=%s', $this->balancer, urlencode($url));
+		}
+
+		$this->lastUrl = $url;
+
+		return $url;
+	}
+
+}

--- a/src/Ares/ApiClient/ResponseCache.php
+++ b/src/Ares/ApiClient/ResponseCache.php
@@ -1,0 +1,172 @@
+<?php declare(strict_types = 1);
+
+namespace Defr\Ares\ApiClient;
+
+use Defr\Ares\AresException;
+use Defr\Ares\AresRecord;
+use Defr\Ares\AresRecords;
+use Defr\Ares\TaxRecord;
+use Defr\Lib;
+
+
+class ResponseCache implements ApiClient
+{
+
+	private string $cacheStrategy = 'YW';
+
+	/**
+	 * Path to directory that serves as an local cache for Ares service responses.
+	 */
+	private ?string $cacheDir = null;
+
+	/**
+	 * Whether we are running in debug/development environment.
+	 */
+	private bool $debug;
+
+	private ApiClient $inner;
+
+	/**
+	 * Last called URL.
+	 */
+	private string $lastUrl;
+
+	public function __construct(ApiClient $innerApiClient, ?string $cacheDir = null, bool $debug = false, ?string $balancer = null)
+	{
+		$this->inner = $innerApiClient;
+
+		if (null === $cacheDir) {
+			$cacheDir = sys_get_temp_dir();
+		}
+
+		if (null !== $balancer) {
+			$this->balancer = $balancer;
+		}
+
+		$this->cacheDir = $cacheDir.'/defr/ares';
+		$this->debug = $debug;
+
+		if (!is_dir($this->cacheDir)) {
+			mkdir($this->cacheDir, 0777, true);
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findByIdentificationNumber($id): AresRecord
+	{
+		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
+		$cachedFile = $this->cacheDir.'/bas_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		$record = $this->inner->findByIdentificationNumber($id);
+
+		file_put_contents($cachedFile, serialize($record));
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findInResById(int $id): AresRecord
+	{
+		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
+		$cachedFile = $this->cacheDir.'/res_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		$record = $this->inner->findInResById($id);
+
+		file_put_contents($cachedFile, serialize($record));
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findVatById(int $id): AresRecord
+	{
+		$cachedFileName = $id.'_'.date($this->cacheStrategy).'.php';
+		$cachedFile = $this->cacheDir.'/tax_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		$record = $this->inner->findVatById($id);
+
+		file_put_contents($cachedFile, serialize($record));
+
+		return $record;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function findByName(string $name, ?string $city = null)
+	{
+		$cachedFileName = date($this->cacheStrategy).'_'.md5($name.$city).'.php';
+		$cachedFile = $this->cacheDir.'/find_'.$cachedFileName;
+
+		if (is_file($cachedFile)) {
+			return unserialize(file_get_contents($cachedFile));
+		}
+
+		$records = $this->inner->findByName($name, $city);
+
+		file_put_contents($cachedFile, serialize($records));
+
+		return $records;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setCacheStrategy(string $cacheStrategy): void
+	{
+		$this->cacheStrategy = $cacheStrategy;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setDebug(bool $debug): void
+	{
+		$this->debug = $debug;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setBalancer(string $balancer)
+	{
+		$this->inner->setBalancer($balancer);
+
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getLastUrl(): string
+	{
+		return $this->inner->getLastUrl();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getLastRawResponse(): ?string
+	{
+		return $this->inner->getLastRawResponse();
+	}
+
+}

--- a/tests/AresTest.php
+++ b/tests/AresTest.php
@@ -15,7 +15,7 @@ final class AresTest extends TestCase
     protected function setUp(): void
     {
         $this->ares = new Ares(null, true);
-		$this->ares->setApiClient(new Ares\ApiClient\AresV1()); // skip caching
+		$this->ares->setApiClient(new Ares\ApiClient\AresV2()); // skip caching
     }
 
     /**

--- a/tests/AresTest.php
+++ b/tests/AresTest.php
@@ -15,6 +15,7 @@ final class AresTest extends TestCase
     protected function setUp(): void
     {
         $this->ares = new Ares(null, true);
+		$this->ares->setApiClient(new Ares\ApiClient\AresV1()); // skip caching
     }
 
     /**
@@ -179,6 +180,7 @@ final class AresTest extends TestCase
     public function testBalancer(): void
     {
         $ares = new Ares();
+		$ares->setApiClient(new Ares\ApiClient\AresV1()); // skip caching
         $ares->setBalancer('http://some.loadbalancer.domain');
         self::expectExceptionMessageMatches('/php_network_getaddresses/');
         try {


### PR DESCRIPTION
Closes #36 

I have:

- decoupled API client from public facade
- decoupled caching from API client
- started implementation of v2 API
- implemented an auto-switch to new API on 1st of October

However I've spent already quite a long time with it so now I put it here so that someone can finish the work. There are TODOs in `AresV2` class - basically 3 of 4 methods have to be rewritten and the already rewritten method has some BC issues which I'm not able to solve on my own. Maybe @dfridrich can look into that BC issues.

Resources:
- announcement: https://www.mfcr.cz/cs/ministerstvo/informacni-systemy/ares--administrativni-registr-ekonomicky
- API base URL: https://ares.gov.cz/ekonomicke-subjekty-v-be/rest/{registry}/{ico}
- API docs: https://ares.gov.cz/swagger-ui
- API fields docs: https://www.mfcr.cz/assets/cs/media/2023-08-01_ARES-Technicka-dokumentace-Katalog-verejnych-sluzeb.pdf
- related upgrading PR in `h4kuna/ares`: https://github.com/h4kuna/ares/pull/31
- registries overview: https://ares.gov.cz/stranky/popis
- old API docs: https://wwwinfo.mfcr.cz/ares/ares_xml.html.en